### PR TITLE
Update to manifest-v3

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -194,12 +194,10 @@ async function registerOrUpdateContentScript() {
 		await unregisterContentScriptSafe("gum-patch");
 		await browser.scripting.registerContentScripts([{
 			id: "gum-patch",
-			js: ["js/patch-gum.js"],
+			js: ["js/inject-gum-patch.js"],
 			matches,
 			allFrames: true,
 			runAt: "document_start",
-			world: "MAIN",
-			persistAcrossSessions: true,
 		}]);
 	}
 	catch (err) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -23,7 +23,10 @@ async function getExtensionSettings() {
 async function extensionSettingsChanged() {
 	console.log("(controller) extension settings changed");
 
-	var prevSettings = extensionSettings;
+    var prevSettings = extensionSettings;
+    if (isPromise(prevSettings)) {
+        prevSettings = await prevSettings;
+    }
 	extensionSettings = await getExtensionSettings();
 
 	// extension now enabled?

--- a/js/inject-gum-patch.js
+++ b/js/inject-gum-patch.js
@@ -1,19 +1,13 @@
 (function InjectGUMPatch(global){
-	"use strict"
+    "use strict"
 
-	if (document.readyState == "loading") {
-		document.addEventListener("DOMContentLoaded",ready);
-	}
-	else {
-		ready();
-	}
-
-
-	// **********************************
-
-	function ready(){
-		var s = document.createElement("script");
-		s.src = (typeof chrome != "undefined" && chrome.runtime && chrome.runtime.getURL) ? chrome.runtime.getURL("js/patch-gum.js") : (browser && browser.runtime.getURL("js/patch-gum.js"));
-		document.head.prepend(s);
-	}
+    try {
+        var s = document.createElement("script");
+        s.src = (typeof chrome != "undefined" && chrome.runtime && chrome.runtime.getURL) ? chrome.runtime.getURL("js/patch-gum.js") : (browser && browser.runtime.getURL("js/patch-gum.js"));
+        var target = document.head || document.documentElement;
+        target.prepend(s);
+    }
+    catch (err) {
+        // best-effort; ignore
+    }
 })();

--- a/js/inject-gum-patch.js
+++ b/js/inject-gum-patch.js
@@ -13,7 +13,7 @@
 
 	function ready(){
 		var s = document.createElement("script");
-		s.src = browser.runtime.getURL("js/patch-gum.js");
+		s.src = (typeof chrome != "undefined" && chrome.runtime && chrome.runtime.getURL) ? chrome.runtime.getURL("js/patch-gum.js") : (browser && browser.runtime.getURL("js/patch-gum.js"));
 		document.head.prepend(s);
 	}
 })();

--- a/js/patch-gum.js
+++ b/js/patch-gum.js
@@ -32,8 +32,6 @@
 	}
 
 	async function getUserMedia(constraints){
-		var editedConstraints = JSON.parse(JSON.stringify(constraints));
-
 		if (constraints && constraints.video) {
 			let editedConstraints = JSON.parse(JSON.stringify(constraints));
 

--- a/js/patch-gum.js
+++ b/js/patch-gum.js
@@ -55,6 +55,29 @@
 				}
 			}
 
+			// attempt to force 60fps if possible
+			if (editedConstraints.video.frameRate) {
+				// if a frameRate is already specified, override it to 60 (exact)
+				editedConstraints.video.frameRate = 60;
+			}
+			else if (Array.isArray(editedConstraints.video.advanced)) {
+				let appliedFrameRate = false;
+				for (let constraint of editedConstraints.video.advanced) {
+					if (constraint && constraint.frameRate) {
+						constraint.frameRate = 60;
+						appliedFrameRate = true;
+					}
+				}
+				if (!appliedFrameRate) {
+					// no existing frameRate constraint found; add one
+					editedConstraints.video.frameRate = 60;
+				}
+			}
+			else {
+				// add a new frameRate constraint if none exists
+				editedConstraints.video.frameRate = 60;
+			}
+
 			try {
 				let result = await origFn.call(navigator.mediaDevices,editedConstraints);
 				if (result) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "HD Camera Feed in Video Calls",
 	"author": "Kyle Simpson",
 	"version": "1",
@@ -13,23 +13,24 @@
 		"128": "images/logo-128.png"
 	},
 	"options_ui": {
-		"page": "settings.html",
-		"chrome_style": true
+		"page": "settings.html"
 	},
 	"background": {
-		"scripts": [
-			"js/external/webextension-polyfill.min.js",
-			"js/controller.js"
-		],
-		"persistent": false
+		"service_worker": "js/controller.js"
 	},
 	"content_scripts": [],
 	"web_accessible_resources": [
-		"js/patch-gum.js"
+		{
+			"resources": ["js/patch-gum.js"],
+			"matches": ["<all_urls>"]
+		}
 	],
 	"permissions": [
-		"https://*/*",
 		"storage",
+		"scripting",
 		"tabs"
+	],
+	"host_permissions": [
+		"https://*/*"
 	]
 }


### PR DESCRIPTION
Feel free to ignore this or not use it, but I am using this locally and figured I'd upstream it. 

Switches the controller script over to be a service worker, register's the inject-gum-patch as a content script on appropriate webpages, and prepends the gum patch to the pages that's needed. 